### PR TITLE
Update `gleam_json` to 2.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27.2"
-          gleam-version: "1.6.3"
+          otp-version: "27.2.1"
+          gleam-version: "1.7.0"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.0.2"
-          gleam-version: "1.4.1"
+          otp-version: "27.2"
+          gleam-version: "1.6.3"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gwt"
-version = "1.0.0"
+version = "2.0.0"
 description = "A JWT library written in Gleam"
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "brettkolodny", repo = "gwt" }

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ repository = { type = "github", user = "brettkolodny", repo = "gwt" }
 
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_json = "~> 2.0"
+gleam_json = ">= 1.0.0 and < 3.0.0"
 gleam_crypto = "~> 1.3"
 birl = "~> 1.7"
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,10 +5,10 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "brettkolodny", repo = "gwt" }
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 gleam_json = ">= 1.0.0 and < 3.0.0"
-gleam_crypto = "~> 1.3"
-birl = "~> 1.7"
+gleam_crypto = ">= 1.3.0 and < 2.0.0"
+birl = ">= 1.7.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
+gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ repository = { type = "github", user = "brettkolodny", repo = "gwt" }
 
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_json = "~> 1.0"
+gleam_json = "~> 2.0"
 gleam_crypto = "~> 1.3"
 birl = "~> 1.7"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -13,8 +13,8 @@ packages = [
 ]
 
 [requirements]
-birl = { version = "~> 1.7" }
-gleam_crypto = { version = "~> 1.3" }
+birl = { version = ">= 1.7.0 and < 2.0.0" }
+gleam_crypto = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_json = { version = ">= 1.0.0 and < 3.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
-gleeunit = { version = "~> 1.0" }
+gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,18 +4,17 @@
 packages = [
   { name = "birl", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "2AC7BA26F998E3DFADDB657148BD5DDFE966958AD4D6D6957DD0D22E5B56C400" },
   { name = "gleam_crypto", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "8AE56026B3E05EBB1F076778478A762E9EB62B31AEEB4285755452F397029D22" },
-  { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
+  { name = "gleam_json", version = "2.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "093214EB186A88D301795A94F0A8128C2E24CF1423997ED31A6C6CC67FC3E1A1" },
   { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
   { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "ranger", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], otp_app = "ranger", source = "hex", outer_checksum = "C8988E8F8CDBD3E7F4D8F2E663EF76490390899C2B2885A6432E942495B3E854" },
-  { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
 ]
 
 [requirements]
 birl = { version = "~> 1.7" }
 gleam_crypto = { version = "~> 1.3" }
-gleam_json = { version = "~> 1.0" }
+gleam_json = { version = "~> 2.0" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,11 +4,11 @@
 packages = [
   { name = "birl", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "2AC7BA26F998E3DFADDB657148BD5DDFE966958AD4D6D6957DD0D22E5B56C400" },
   { name = "gleam_crypto", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "8AE56026B3E05EBB1F076778478A762E9EB62B31AEEB4285755452F397029D22" },
-  { name = "gleam_json", version = "2.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "093214EB186A88D301795A94F0A8128C2E24CF1423997ED31A6C6CC67FC3E1A1" },
+  { name = "gleam_json", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "C55C5C2B318533A8072D221C5E06E5A75711C129E420DD1CE463342106012E5D" },
   { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
-  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
+  { name = "gleam_stdlib", version = "0.54.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "723BA61A2BAE8D67406E59DD88CEA1B3C3F266FC8D70F64BE9FEC81B4505B927" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
   { name = "ranger", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], otp_app = "ranger", source = "hex", outer_checksum = "C8988E8F8CDBD3E7F4D8F2E663EF76490390899C2B2885A6432E942495B3E854" },
 ]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "birl", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "B1FA529E7BE3FF12CADF32814AB8EC7294E74CEDEE8CC734505707B929A98985" },
-  { name = "gleam_crypto", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "ADD058DEDE8F0341F1ADE3AAC492A224F15700829D9A3A3F9ADF370F875C51B7" },
+  { name = "birl", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "2AC7BA26F998E3DFADDB657148BD5DDFE966958AD4D6D6957DD0D22E5B56C400" },
+  { name = "gleam_crypto", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "8AE56026B3E05EBB1F076778478A762E9EB62B31AEEB4285755452F397029D22" },
   { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
-  { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
-  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "ranger", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], otp_app = "ranger", source = "hex", outer_checksum = "C8988E8F8CDBD3E7F4D8F2E663EF76490390899C2B2885A6432E942495B3E854" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
 ]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -15,6 +15,6 @@ packages = [
 [requirements]
 birl = { version = "~> 1.7" }
 gleam_crypto = { version = "~> 1.3" }
-gleam_json = { version = "~> 2.0" }
+gleam_json = { version = ">= 1.0.0 and < 3.0.0" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/gwt.gleam
+++ b/src/gwt.gleam
@@ -738,9 +738,10 @@ fn parts(
 ) {
   let parts = string.split(jwt_string, ".")
 
-  use #(encoded_header, parts) <- result.try(
-    list.pop(parts, fn(_) { True }) |> result.replace_error(MissingHeader),
+  use encoded_header <- result.try(
+    list.first(parts) |> result.replace_error(MissingHeader),
   )
+  let parts = list.drop(parts, 1)
   use header_string <- result.try(
     encoded_header
     |> bit_array.base64_url_decode()
@@ -752,9 +753,10 @@ fn parts(
     |> result.replace_error(InvalidHeader),
   )
 
-  use #(encoded_payload, parts) <- result.try(
-    list.pop(parts, fn(_) { True }) |> result.replace_error(MissingPayload),
+  use encoded_payload <- result.try(
+    list.first(parts) |> result.replace_error(MissingPayload),
   )
+  let parts = list.drop(parts, 1)
   use payload_string <- result.try(
     encoded_payload
     |> bit_array.base64_url_decode()

--- a/src/gwt.gleam
+++ b/src/gwt.gleam
@@ -27,7 +27,7 @@ pub opaque type JwtBuilder {
   JwtBuilder(header: Dict(String, Json), payload: Dict(String, Json))
 }
 
-/// A decoded JWT that can be read. The phantom type `status` indicated if it's 
+/// A decoded JWT that can be read. The phantom type `status` indicated if it's
 /// signature was verified or not.
 ///
 pub opaque type Jwt(status) {
@@ -82,12 +82,12 @@ pub type Algorithm {
 
 // CONSTRUCTORS ----------------------------------------------------------------
 
-/// Creates a JwtBuilder with an empty payload and a header that only 
+/// Creates a JwtBuilder with an empty payload and a header that only
 /// contains the cliams `"typ": "JWT"`, and `"alg": "none"`.
 ///
 /// ```gleam
 /// import gwt.{type Jwt, type Unverified}
-/// 
+///
 /// fn example() -> JwtBuilder {
 ///   gwt.new()
 /// }
@@ -104,12 +104,12 @@ pub fn new() -> JwtBuilder {
 }
 
 /// Decode a JWT string into an unverified [Jwt](#Jwt).
-/// 
+///
 /// Returns `Ok(JwtBuilder)` if it is a valid JWT, and `Error(JwtDecodeError)` otherwise.
 ///
 /// ```gleam
 /// import gwt.{type Jwt, type Unverified, type JwtDecodeError}
-/// 
+///
 /// fn example(jwt_string: String) -> Result(JwtBuilder, JwtDecodeError) {
 ///   gwt.from_string(jwt_string)
 /// }
@@ -123,7 +123,7 @@ pub fn from_string(
 }
 
 /// Decode a signed JWT string into a verified [Jwt](#Jwt).
-/// 
+///
 /// Returns `Ok(JwtBuilder)` if it is a valid JWT and the JWT's signature is successfully verified,
 /// and `Error(JwtDecodeError)` otherwise.
 ///
@@ -132,7 +132,7 @@ pub fn from_string(
 ///
 /// ```gleam
 /// import gwt.{type Jwt, type Verified, type JwtDecodeError}
-/// 
+///
 /// fn example(jwt_string: String) -> Result(Jwt(Verified), JwtDecodeError) {
 ///   gwt.from_signed_string(jwt_string, "some secret")
 /// }
@@ -184,16 +184,16 @@ pub fn from_signed_string(
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example()  {
-///   let jwt_with_iss = 
+///   let jwt_with_iss =
 ///     gwt.new()
 ///     |> jwt.set_issuer("gleam")
-/// 
+///
 ///   let assert Ok(issuer) = gwt.get_issuer(jwt_with_iss)
-/// 
+///
 ///   let jwt_without_iss = gwt.new()
-/// 
+///
 ///   let assert Error(MissingClaim) = gwt.get_issuer(jwt_without_iss)
 /// }
 /// ```
@@ -211,16 +211,16 @@ pub fn get_issuer(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example()  {
-///   let jwt_with_sub = 
+///   let jwt_with_sub =
 ///     gwt.new()
 ///     |> jwt.set_subject("gleam")
-/// 
+///
 ///   let assert Ok(subject) = gwt.get_issuer(jwt_with_sub)
-/// 
+///
 ///   let jwt_without_sub = gwt.new()
-/// 
+///
 ///   let assert Error(MissingClaim) = gwt.get_subject(jwt_without_sub)
 /// }
 /// ```
@@ -238,16 +238,16 @@ pub fn get_subject(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example()  {
-///   let jwt_with_aud = 
+///   let jwt_with_aud =
 ///     gwt.new()
 ///     |> jwt.set_audience("gleam")
-/// 
+///
 ///   let assert Ok(audience) = gwt.get_audience(jwt_with_aud)
-/// 
+///
 ///   let jwt_without_aud = gwt.new()
-/// 
+///
 ///   let assert Error(MissingClaim) = gwt.get_audience(jwt_without_aud)
 /// }
 /// ```
@@ -265,16 +265,16 @@ pub fn get_audience(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example()  {
-///   let jwt_with_jti = 
+///   let jwt_with_jti =
 ///     gwt.new()
 ///     |> jwt.set_jwt_id("gleam")
-/// 
+///
 ///   let assert Ok(jwt_id) = gwt.get_jwt_id(jwt_with_jti)
-/// 
+///
 ///   let jwt_without_jti = gwt.new()
-/// 
+///
 ///   let assert Error(MissingClaim) = gwt.get_jwt_id(jwt_without_jti)
 /// }
 /// ```
@@ -292,16 +292,16 @@ pub fn get_jwt_id(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example()  {
-///   let jwt_with_iat = 
+///   let jwt_with_iat =
 ///     gwt.new()
 ///     |> jwt.set_issued_at("gleam")
-/// 
+///
 ///   let assert Ok(issued_at) = gwt.get_issued_at(jwt_with_iat)
-/// 
+///
 ///   let jwt_without_iat = gwt.new()
-/// 
+///
 ///   let assert Error(MissingClaim) = gwt.get_issued_at(jwt_without_iat)
 /// }
 /// ```
@@ -319,16 +319,16 @@ pub fn get_issued_at(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example()  {
-///   let jwt_with_sub = 
+///   let jwt_with_sub =
 ///     gwt.new()
 ///     |> jwt.set_not_before("gleam")
-/// 
+///
 ///   let assert Ok(not_before) = gwt.get_not_before(jwt_with_nbf)
-/// 
+///
 ///   let jwt_without_nbf = gwt.new()
-/// 
+///
 ///   let assert Error(MissingClaim) = gwt.get_not_before(jwt_without_nbf)
 /// }
 /// ```
@@ -346,16 +346,16 @@ pub fn get_not_before(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example()  {
-///   let jwt_with_exp = 
+///   let jwt_with_exp =
 ///     gwt.new()
 ///     |> jwt.set_not_before("gleam")
-/// 
+///
 ///   let assert Ok(expiration) = gwt.get_not_before(jwt_with_exp)
-/// 
+///
 ///   let jwt_without_exp = gwt.new()
-/// 
+///
 ///   let assert Error(MissingClaim) = gwt.get_not_before(jwt_without_exp)
 /// }
 /// ```
@@ -372,15 +372,15 @@ pub fn get_expiration(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
 /// import gwt
 /// import gleam/json
 /// import gleam/dynamic
-/// 
+///
 /// fn example() {
 ///   let jwt_with_custom_claim =
 ///     gwt.new()
 ///     |> gwt.set_payload_claim("gleam", json.string("lucy"))
-/// 
+///
 ///   let assert Ok("lucy") =
 ///     gwt.get_payload_claim(jwt_with_custom_claim, "gleam", dynamic.string)
-/// 
+///
 ///   let assert Error(MissingClaim) =
 ///     gwt.get_payload_claim(jwt_with_custom_claim, "gleam", dynamic.int)
 /// }
@@ -406,12 +406,12 @@ pub fn get_payload_claim(
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example() {
 ///   gwt.new()
 ///   |> gwt.set_issuer("gleam")
 /// }
-/// ``` 
+/// ```
 ///
 pub fn set_issuer(jwt: JwtBuilder, to iss: String) -> JwtBuilder {
   let new_payload = dict.insert(jwt.payload, "iss", json.string(iss))
@@ -423,12 +423,12 @@ pub fn set_issuer(jwt: JwtBuilder, to iss: String) -> JwtBuilder {
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example() {
 ///   gwt.new()
 ///   |> gwt.set_subject("gleam")
 /// }
-/// ``` 
+/// ```
 ///
 pub fn set_subject(jwt: JwtBuilder, to sub: String) -> JwtBuilder {
   let payload = dict.insert(jwt.payload, "sub", json.string(sub))
@@ -440,12 +440,12 @@ pub fn set_subject(jwt: JwtBuilder, to sub: String) -> JwtBuilder {
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example() {
 ///   gwt.new()
 ///   |> gwt.set_audience("gleam")
 /// }
-/// ``` 
+/// ```
 ///
 pub fn set_audience(jwt: JwtBuilder, to aud: String) -> JwtBuilder {
   let payload = dict.insert(jwt.payload, "aud", json.string(aud))
@@ -458,14 +458,14 @@ pub fn set_audience(jwt: JwtBuilder, to aud: String) -> JwtBuilder {
 /// ```gleam
 /// import gwt
 /// import birl
-/// 
+///
 /// fn example() {
 ///   let five_minutes = birl.to_unix(birl.now()) + 300
-/// 
+///
 ///   gwt.new()
 ///   |> gwt.set_expiration(five_minutes)
 /// }
-/// ``` 
+/// ```
 ///
 pub fn set_expiration(jwt: JwtBuilder, to exp: Int) -> JwtBuilder {
   let payload = dict.insert(jwt.payload, "exp", json.int(exp))
@@ -478,14 +478,14 @@ pub fn set_expiration(jwt: JwtBuilder, to exp: Int) -> JwtBuilder {
 /// ```gleam
 /// import gwt
 /// import birl
-/// 
+///
 /// fn example() {
 ///   let five_minutes = birl.to_unix(birl.now()) + 300
-/// 
+///
 ///   gwt.new()
 ///   |> gwt.set_not_before(five_minutes)
 /// }
-/// ``` 
+/// ```
 ///
 pub fn set_not_before(jwt: JwtBuilder, to nbf: Int) -> JwtBuilder {
   let payload = dict.insert(jwt.payload, "nbf", json.int(nbf))
@@ -498,12 +498,12 @@ pub fn set_not_before(jwt: JwtBuilder, to nbf: Int) -> JwtBuilder {
 /// ```gleam
 /// import gwt
 /// import birl
-/// 
+///
 /// fn example() {
 ///   gwt.new()
 ///   |> gwt.set_issued_at(birl.to_unix(birl.now()))
 /// }
-/// ``` 
+/// ```
 ///
 pub fn set_issued_at(jwt: JwtBuilder, to iat: Int) -> JwtBuilder {
   let payload = dict.insert(jwt.payload, "iat", json.int(iat))
@@ -516,12 +516,12 @@ pub fn set_issued_at(jwt: JwtBuilder, to iat: Int) -> JwtBuilder {
 /// ```gleam
 /// import gwt
 /// import birl
-/// 
+///
 /// fn example() {
 ///   gwt.new()
 ///   |> gwt.set_jwt_id("gleam")
 /// }
-/// ``` 
+/// ```
 ///
 pub fn set_jwt_id(jwt: JwtBuilder, to jti: String) -> JwtBuilder {
   let payload = dict.insert(jwt.payload, "jti", json.string(jti))
@@ -534,12 +534,12 @@ pub fn set_jwt_id(jwt: JwtBuilder, to jti: String) -> JwtBuilder {
 /// ```gleam
 /// import gleam/json
 /// import gwt
-/// 
+///
 /// fn example() {
 ///   gwt.new()
 ///   |> gwt.set_payload_claim("gleam", json.string("lucy"))
 /// }
-/// ``` 
+/// ```
 ///
 pub fn set_payload_claim(
   jwt: JwtBuilder,
@@ -558,12 +558,12 @@ pub fn set_payload_claim(
 /// ```gleam
 /// import gleam/json
 /// import gwt
-/// 
+///
 /// fn example() {
 ///   gwt.new()
 ///   |> gwt.set_header_claim("gleam", json.string("lucy"))
 /// }
-/// ``` 
+/// ```
 ///
 pub fn set_header_claim(
   jwt: JwtBuilder,
@@ -583,15 +583,15 @@ pub fn set_header_claim(
 /// import gwt
 /// import gleam/json
 /// import gleam/dynamic
-/// 
+///
 /// fn example() {
 ///   let jwt_with_custom_claim =
 ///     gwt.new()
 ///     |> gwt.set_header_claim("gleam", json.string("lucy"))
-/// 
+///
 ///   let assert Ok("lucy") =
 ///     gwt.get_header_claim(jwt_with_custom_claim, "gleam", dynamic.string)
-/// 
+///
 ///   let assert Error(MissingClaim) =
 ///     gwt.get_header_claim(jwt_with_custom_claim, "gleam", dynamic.int)
 /// }
@@ -618,13 +618,13 @@ pub fn get_header_claim(
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example() {
 ///   gwt.new()
 ///   |> gwt.set_issuer("gleam")
 ///   |> gwt.to_string()
 /// }
-/// ``` 
+/// ```
 ///
 pub fn to_string(jwt: JwtBuilder) -> String {
   let JwtBuilder(header, payload) = jwt
@@ -650,13 +650,13 @@ pub fn to_string(jwt: JwtBuilder) -> String {
 ///
 /// ```gleam
 /// import gwt
-/// 
+///
 /// fn example() {
 ///   gwt.new()
 ///   |> gwt.set_issuer("gleam")
 ///   |> gwt.to_signed_string(gwt.HS256, "lucy")
 /// }
-/// ``` 
+/// ```
 ///
 pub fn to_signed_string(
   jwt: JwtBuilder,

--- a/src/gwt.gleam
+++ b/src/gwt.gleam
@@ -609,7 +609,7 @@ pub fn get_header_claim(
 
   claim_value
   |> decoder()
-  |> result.nil_error()
+  |> result.replace_error(Nil)
 }
 
 // ENCODER ---------------------------------------------------------------------

--- a/src/gwt.gleam
+++ b/src/gwt.gleam
@@ -4,7 +4,8 @@ import birl
 import gleam/bit_array
 import gleam/crypto
 import gleam/dict.{type Dict}
-import gleam/dynamic.{type DecodeError, type Dynamic}
+import gleam/dynamic
+import gleam/dynamic/decode.{type DecodeError, type Decoder, type Dynamic}
 import gleam/json.{type Json}
 import gleam/list
 import gleam/option.{type Option, None, Some}
@@ -199,7 +200,7 @@ pub fn from_signed_string(
 /// ```
 ///
 pub fn get_issuer(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
-  get_payload_claim(jwt, "iss", dynamic.string)
+  get_payload_claim(jwt, "iss", decode.string)
 }
 
 /// Retrieve the sub from the JWT's payload.
@@ -226,7 +227,7 @@ pub fn get_issuer(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
 /// ```
 ///
 pub fn get_subject(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
-  get_payload_claim(jwt, "sub", dynamic.string)
+  get_payload_claim(jwt, "sub", decode.string)
 }
 
 /// Retrieve the aud from the JWT's payload.
@@ -253,7 +254,7 @@ pub fn get_subject(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
 /// ```
 ///
 pub fn get_audience(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
-  get_payload_claim(jwt, "aud", dynamic.string)
+  get_payload_claim(jwt, "aud", decode.string)
 }
 
 /// Retrieve the jti from the JWT's payload.
@@ -280,7 +281,7 @@ pub fn get_audience(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
 /// ```
 ///
 pub fn get_jwt_id(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
-  get_payload_claim(jwt, "jti", dynamic.string)
+  get_payload_claim(jwt, "jti", decode.string)
 }
 
 /// Retrieve the iat from the JWT's payload.
@@ -307,7 +308,7 @@ pub fn get_jwt_id(from jwt: Jwt(status)) -> Result(String, JwtDecodeError) {
 /// ```
 ///
 pub fn get_issued_at(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
-  get_payload_claim(jwt, "iat", dynamic.int)
+  get_payload_claim(jwt, "iat", decode.int)
 }
 
 /// Retrieve the nbf from the JWT's payload.
@@ -334,7 +335,7 @@ pub fn get_issued_at(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
 /// ```
 ///
 pub fn get_not_before(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
-  get_payload_claim(jwt, "nbf", dynamic.int)
+  get_payload_claim(jwt, "nbf", decode.int)
 }
 
 /// Retrieve the exp from the JWT's payload.
@@ -361,7 +362,7 @@ pub fn get_not_before(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
 /// ```
 ///
 pub fn get_expiration(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
-  get_payload_claim(jwt, "exp", dynamic.int)
+  get_payload_claim(jwt, "exp", decode.int)
 }
 
 /// Retrieve and decode a claim from a JWT's payload.
@@ -371,7 +372,7 @@ pub fn get_expiration(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
 /// ```gleam
 /// import gwt
 /// import gleam/json
-/// import gleam/dynamic
+/// import gleam/dynamic/decode
 ///
 /// fn example() {
 ///   let jwt_with_custom_claim =
@@ -379,17 +380,17 @@ pub fn get_expiration(from jwt: Jwt(status)) -> Result(Int, JwtDecodeError) {
 ///     |> gwt.set_payload_claim("gleam", json.string("lucy"))
 ///
 ///   let assert Ok("lucy") =
-///     gwt.get_payload_claim(jwt_with_custom_claim, "gleam", dynamic.string)
+///     gwt.get_payload_claim(jwt_with_custom_claim, "gleam", decode.string)
 ///
 ///   let assert Error(MissingClaim) =
-///     gwt.get_payload_claim(jwt_with_custom_claim, "gleam", dynamic.int)
+///     gwt.get_payload_claim(jwt_with_custom_claim, "gleam", decode.int)
 /// }
 /// ```
 ///
 pub fn get_payload_claim(
   from jwt: Jwt(status),
   claim claim: String,
-  decoder decoder: fn(Dynamic) -> Result(a, List(dynamic.DecodeError)),
+  decoder decoder: Decoder(a),
 ) -> Result(a, JwtDecodeError) {
   use claim_value <- result.try(
     jwt.payload
@@ -397,8 +398,7 @@ pub fn get_payload_claim(
     |> result.replace_error(MissingClaim),
   )
 
-  claim_value
-  |> decoder()
+  decode.run(claim_value, decoder)
   |> result.map_error(fn(e) { InvalidClaim(e) })
 }
 
@@ -600,7 +600,7 @@ pub fn set_header_claim(
 pub fn get_header_claim(
   from jwt: Jwt(status),
   claim claim: String,
-  decoder decoder: fn(Dynamic) -> Result(a, List(dynamic.DecodeError)),
+  decoder decoder: fn(Dynamic) -> Result(a, List(DecodeError)),
 ) -> Result(a, Nil) {
   use claim_value <- result.try(
     jwt.header
@@ -748,7 +748,7 @@ fn parts(
     |> result.replace_error(InvalidHeader),
   )
   use header <- result.try(
-    json.decode(header_string, dynamic.dict(dynamic.string, dynamic.dynamic))
+    json.parse(header_string, decode.dict(decode.string, decode.dynamic))
     |> result.replace_error(InvalidHeader),
   )
 
@@ -762,7 +762,7 @@ fn parts(
     |> result.replace_error(InvalidPayload),
   )
   use payload <- result.try(
-    json.decode(payload_string, dynamic.dict(dynamic.string, dynamic.dynamic))
+    json.parse(payload_string, decode.dict(decode.string, decode.dynamic))
     |> result.replace_error(InvalidPayload),
   )
 
@@ -783,7 +783,7 @@ fn ensure_valid_expiration(
       |> result.or(Ok(dynamic.from(-1)))
       |> result.replace_error(InvalidHeader),
     )
-    dynamic.int(exp)
+    decode.run(exp, decode.int)
     |> result.replace_error(InvalidHeader)
   }
   use exp <- result.try(exp)
@@ -815,7 +815,7 @@ fn ensure_valid_not_before(
       |> result.or(Ok(dynamic.from(-1)))
       |> result.replace_error(InvalidHeader),
     )
-    dynamic.int(nbf)
+    decode.run(nbf, decode.int)
     |> result.replace_error(InvalidHeader)
   }
   use nbf <- result.try(nbf)
@@ -847,6 +847,6 @@ fn ensure_valid_alg(
   )
 
   alg
-  |> dynamic.string()
+  |> decode.run(decode.string)
   |> result.replace_error(InvalidAlg)
 }

--- a/test/gwt_test.gleam
+++ b/test/gwt_test.gleam
@@ -1,5 +1,5 @@
 import birl
-import gleam/dynamic
+import gleam/dynamic/decode
 import gleam/json
 import gleeunit
 import gleeunit/should
@@ -32,11 +32,11 @@ pub fn encode_decode_unsigned_jwt_test() {
   |> should.equal(Ok("1234567890"))
 
   jwt
-  |> gwt.get_payload_claim("aud", dynamic.string)
+  |> gwt.get_payload_claim("aud", decode.string)
   |> should.equal(Ok("0987654321"))
 
   jwt
-  |> gwt.get_payload_claim("iss", dynamic.string)
+  |> gwt.get_payload_claim("iss", decode.string)
   |> should.equal(Error(gwt.MissingClaim))
 }
 
@@ -63,11 +63,11 @@ pub fn encode_decode_signed_jwt_test() {
   |> should.equal(Ok("1234567890"))
 
   jwt
-  |> gwt.get_payload_claim("aud", dynamic.string)
+  |> gwt.get_payload_claim("aud", decode.string)
   |> should.equal(Ok("0987654321"))
 
   jwt
-  |> gwt.get_payload_claim("iss", dynamic.string)
+  |> gwt.get_payload_claim("iss", decode.string)
   |> should.equal(Error(gwt.MissingClaim))
 
   let jwt =
@@ -150,10 +150,15 @@ pub fn custom_payload_test() {
     |> gwt.from_string()
 
   jwt
-  |> gwt.get_payload_claim("email", dynamic.string)
+  |> gwt.get_payload_claim("email", decode.string)
   |> should.equal(Ok("lucy@gleam.run"))
 
+  let data_decoder = {
+    use age <- decode.field("age", decode.int)
+    decode.success(age)
+  }
+
   jwt
-  |> gwt.get_payload_claim("data", dynamic.field("age", dynamic.int))
+  |> gwt.get_payload_claim("data", data_decoder)
   |> should.equal(Ok(27))
 }


### PR DESCRIPTION
This PR closes #4 

This PR is broken down into a few steps:

1. Updates all in-range deps.
2. Updates `gleam_json`'s range to `2.x` along with it's locked version.
3. Fixes a [deprecation introduced by `gleam_stdlib`](https://hexdocs.pm/gleam_stdlib/gleam/result.html#nil_error) update.
4. Updates the GitHub Action's testing environment (gleam and erlang versions).
5. Bumps semvar major version of this lib due to the [new OTP27 requirement](https://hexdocs.pm/gleam_json/).

- [x] Builds Locally
- [x] Tests Run Locally

Let me know if I missed anything or you need something changed! :rocket: 