### PR TITLE
Use crypto.secure_compare to verify signature

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gwt"
-version = "2.1.1"
+version = "2.1.2"
 description = "A JWT library written in Gleam"
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "brettkolodny", repo = "gwt" }

--- a/src/gwt.gleam
+++ b/src/gwt.gleam
@@ -163,7 +163,12 @@ pub fn from_signed_string(
 
       let sig =
         get_signature(encoded_header <> "." <> encoded_payload, alg, secret)
-      case sig == signature {
+      case
+        crypto.secure_compare(
+          bit_array.from_string(sig),
+          bit_array.from_string(signature),
+        )
+      {
         True -> {
           Ok(Jwt(header: header, payload: payload))
         }


### PR DESCRIPTION
I received an email pointing out that the current way this library is verifying signatures opens it up to [timing attacks](http://codahale.com/a-lesson-in-timing-attacks/). This PR switches the logic to use [crypto.secure_compare](https://hexdocs.pm/gleam_crypto/gleam/crypto.html#secure_compare).